### PR TITLE
use default credential provider chain for s3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject uio/uio "1.1"
+(defproject uio/uio "1.2-SNAPSHOT"
   :description "uio is a Clojure/Java library for accessing HDFS, S3, SFTP and other file systems via a single API."
 
   :repositories {"cloudera" "https://repository.cloudera.com/content/groups/cdh-releases-rcs"}
@@ -8,8 +8,8 @@
 
   :dependencies [[org.clojure/clojure "1.8.0"]
 
-                 [com.amazonaws/aws-java-sdk-s3 "1.11.261"] ; s3
-                 [com.amazonaws/aws-java-sdk-sts "1.11.261"] ; s3 with roles
+                 [com.amazonaws/aws-java-sdk-s3 "1.12.31"] ; s3
+                 [com.amazonaws/aws-java-sdk-sts "1.12.31"] ; s3 with roles
                  [org.apache.httpcomponents/httpclient "4.5.4"] ; (needed by `aws-java-sdk-s3`)
 
                  [com.jcraft/jsch "0.1.54"]                 ; sftp

--- a/src/uio/impl.clj
+++ b/src/uio/impl.clj
@@ -182,10 +182,6 @@
               :access                  (or (cr :access)        (c :s3.access)                (e "AWS_ACCESS")            (e "AWS_ACCESS_KEY_ID"))
               :secret                  (or (cr :secret)        (c :s3.secret)                (e "AWS_SECRET")            (e "AWS_SECRET_ACCESS_KEY"))}
 
-      "s3"   {:access                  (or (cr :access)        (c :s3.access)                (e "AWS_ACCESS")            (e "AWS_ACCESS_KEY_ID")      (die-no-key :access))
-              :secret                  (or (cr :secret)        (c :s3.secret)                (e "AWS_SECRET")            (e "AWS_SECRET_ACCESS_KEY")  (die-no-key :secret))
-              :role-arn                    (cr :role-arn)}
-
       "sftp" {:user                    (or (cr :user)          (c :sftp.user)                (e "SFTP_USER")             (e "SSH_USER")               (die-no-key :user))
               :known-hosts             (or (cr :known-hosts)   (c :sftp.known-hosts)         (e "SFTP_KNOWN_HOSTS")      (e "SSH_KNOWN_HOSTS")        (die-no-key :known-hosts))
               :pass                    (or (cr :pass)          (c :sftp.pass)                (e "SFTP_PASS")             (e "SSH_PASS"))


### PR DESCRIPTION
Now we use not only the `AWS_SECRET` and `AWS_SECRET_ACCESS_KEY` and assumed role, but also web token identity provider for example, it would be better to use the default credential provider chain provided in the image.

Bump the aws sdk version.