### PR TITLE
Check for configured cred overrides in s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Changed
+- S3 fs checks for configured access and secret overrides again.
+
 ## [1.2] - 2021-12-06
 ### Fixed
 - proper escaping of ` `, `+` and `%` in `file://`, `hdfs://`, `s3://` and `sftp://`


### PR DESCRIPTION
Removing this aspect prevented our deployers from properly choosing configured creds that are for specific deployment urls.


Tests:
https://vineyard.k8s.foursquare.com/task/api-211216-223003-kuwuhe-766
https://vineyard.k8s.foursquare.com/task/nohostname-211217-022203-napana-024
https://vineyard.k8s.foursquare.com/task/nohostname-211217-172240-numuli-005