### PR TITLE
DEL-2151 S3 upload no longer validates ETag against MD5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- S3OutputStream no longer validates a Multipart Upload's ETag against its MD5 digest. [DEL-2151](https://foursquare.atlassian.net/browse/DEL-2151)
 
 ## [1.2.2] - 2022-9-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Fixed
-- S3OutputStream no longer validates a Multipart Upload's ETag against its MD5 digest. [DEL-2151](https://foursquare.atlassian.net/browse/DEL-2151)
+- S3OutputStream no longer validates a Multipart Upload's ETag against its MD5 digest, according to [this](https://stackoverflow.com/a/53886736). [DEL-2151](https://foursquare.atlassian.net/browse/DEL-2151)
 
 ## [1.2.2] - 2022-9-16
 ### Added

--- a/src/uio/fs/S3.java
+++ b/src/uio/fs/S3.java
@@ -81,7 +81,6 @@ public class S3 {
         private void _flush(boolean isLastPart) throws IOException {
             partOutputStream.close();
 
-            String localPartEtag = hex(partDigest.digest());
             try {
                 UploadPartRequest upr = new UploadPartRequest()
                         .withBucketName(init.getBucketName())
@@ -119,15 +118,12 @@ public class S3 {
                             " - read   : " + read + "\n" +
                             " - written: " + written);
 
-                String remoteEtag = c.completeMultipartUpload(
-                        new CompleteMultipartUploadRequest(init.getBucketName(), init.getKey(), init.getUploadId(), tags)
-                ).getETag();
+                c.completeMultipartUpload(new CompleteMultipartUploadRequest(init.getBucketName(), init.getKey(), init.getUploadId(), tags));
 
                 partDigest.reset();
                 for (PartETag tag : tags) {
                     partDigest.update(unhex(tag.getETag()));
                 }
-                String localEtag = hex(partDigest.digest()) + "-" + partIndex;
 
             } catch (Exception e) {
                 abort(); // TODO delete remote file if exception happened after `c.completeMultipartUpload(...)`

--- a/src/uio/fs/S3.java
+++ b/src/uio/fs/S3.java
@@ -86,11 +86,6 @@ public class S3 {
                 PartETag remotePartEtag = c.uploadPart(upr).getPartETag();
                 tags.add(remotePartEtag);
 
-                if (!remotePartEtag.getETag().equals(localPartEtag)) {
-                    throw new RuntimeException("Part ETags don't match:\n" +
-                            " - local : " + localPartEtag + "\n" +
-                            " - remote: " + remotePartEtag.getETag());
-                }
 
                 partIndex++;
             } catch (Exception e) {
@@ -120,10 +115,6 @@ public class S3 {
                 }
                 String localEtag = hex(localPartDigest.digest()) + "-" + partIndex;
 
-                if (!localEtag.equals(remoteEtag))
-                    throw new RuntimeException("Etags don't match:\n" +
-                            " - local : " + localEtag + "\n" +
-                            " - remote: " + remoteEtag);
             } catch (Exception e) {
                 abort(); // TODO delete remote file if exception happened after `c.completeMultipartUpload(...)`
                 throw e;

--- a/src/uio/fs/S3.java
+++ b/src/uio/fs/S3.java
@@ -29,7 +29,6 @@ public class S3 {
 
         private final MessageDigest inDigest = MessageDigest.getInstance("MD5");
         private final MessageDigest outDigest = MessageDigest.getInstance("MD5");
-        private final MessageDigest partDigest = MessageDigest.getInstance("MD5");
 
         private final File partTempFile;
         private Streams.StatsableOutputStream partOutputStream;
@@ -65,7 +64,6 @@ public class S3 {
                 // append to buffer
                 partOutputStream.write(bs, offset, bytesToCopy);
 
-                partDigest.update(bs, offset, bytesToCopy);
                 outDigest.update(bs, offset, bytesToCopy);
 
                 offset += bytesToCopy;
@@ -95,7 +93,6 @@ public class S3 {
                 tags.add(remotePartEtag);
 
 
-                partDigest.reset();
                 partOutputStream = new Streams.StatsableOutputStream(new FileOutputStream(partTempFile));
                 partIndex++;
             } catch (Exception e) {
@@ -119,11 +116,6 @@ public class S3 {
                             " - written: " + written);
 
                 c.completeMultipartUpload(new CompleteMultipartUploadRequest(init.getBucketName(), init.getKey(), init.getUploadId(), tags));
-
-                partDigest.reset();
-                for (PartETag tag : tags) {
-                    partDigest.update(unhex(tag.getETag()));
-                }
 
             } catch (Exception e) {
                 abort(); // TODO delete remote file if exception happened after `c.completeMultipartUpload(...)`


### PR DESCRIPTION
S3OutputStream no longer validates a Multipart Upload's ETag against its MD5 digest, according to [this](https://stackoverflow.com/a/53886736). [DEL-2151](https://foursquare.atlassian.net/browse/DEL-2151)

[DEL-2151]: https://foursquare.atlassian.net/browse/DEL-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ